### PR TITLE
prevent error 500: Class cachestore_apc contains 1 abstract method an…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -28,7 +28,7 @@
  * @copyright  2012 Sam Hemelryk
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class cachestore_apc extends cache_store implements cache_is_key_aware {
+abstract class cachestore_apc extends cache_store implements cache_is_key_aware {
 
     /**
      * The required version of APC for this extension.


### PR DESCRIPTION
…d must therefore be declared abstract or implement the remaining methods (cache_store_interface::unit_test_configuration)